### PR TITLE
UHF-X: Unify strategia project url structure on local to same as other local instances

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -26,7 +26,7 @@ server {
 
     # Strategia/talous.
     location ~ ^/(fi/paatoksenteko-ja-hallinto|sv/beslutsfattande-och-forvaltning|en/decision-making|hallinto-assets/) {
-      proxy_set_header Host ${VARNISH_PREFIX}strategia.docker.so;
+      proxy_set_header Host ${VARNISH_PREFIX}helfi-strategia.docker.so;
       proxy_pass https://helfi-backend:443;
     }
 


### PR DESCRIPTION
# UHF-X: Unify strategia project url structure on local to same as other local instances
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the local url format to helfi-strategia.docker.so from just strategia.docker.so

## How to install

* No need to install.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards.

## Other pull requests

* https://github.com/City-of-Helsinki/drupal-helfi-local-proxy/pull/2
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/670